### PR TITLE
Support Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 sudo: false
 language: go
+os: osx
+go:
+  - "1.8.7"
+  - "1.9.4"
+  - "1.10"
+  - "stable"
 
 matrix:
   include:
     - os: osx
-      osx_image: xcode8.1 # macOS 10.12
+      osx_image: xcode8.3 # macOS 10.12
     - os: osx
       osx_image: xcode7.3 # macOS 10.11
     - os: osx
@@ -12,7 +18,7 @@ matrix:
   fast_finish: true
 
 before_script:
-  - sw_vers
+  - if which sw_vers; then sw_vers; fi
   - go get -u github.com/golang/lint/golint
 
 script:

--- a/fsevents.go
+++ b/fsevents.go
@@ -150,6 +150,9 @@ func (r *eventStreamRegistry) Delete(i uintptr) {
 
 // Start listening to an event stream.
 func (es *EventStream) Start() {
+	if es.Events == nil {
+		es.Events = make(chan []Event)
+	}
 
 	// register eventstream in the local registry for later lookup
 	// in C callback
@@ -157,9 +160,6 @@ func (es *EventStream) Start() {
 	es.registryID = cbInfo
 	es.uuid = GetDeviceUUID(es.Device)
 	es.start(es.Paths, cbInfo)
-	if es.Events == nil {
-		es.Events = make(chan []Event)
-	}
 }
 
 // Flush events that have occurred but haven't been delivered.

--- a/fsevents_test.go
+++ b/fsevents_test.go
@@ -1,3 +1,52 @@
 // +build darwin
 
 package fsevents
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBasicExample(t *testing.T) {
+	path, err := ioutil.TempDir("", "fsexample")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(path)
+
+	dev, err := DeviceForPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	es := &EventStream{
+		Paths:   []string{path},
+		Latency: 500 * time.Millisecond,
+		Device:  dev,
+		Flags:   FileEvents,
+	}
+
+	es.Start()
+
+	wait := make(chan Event)
+	go func() {
+		for msg := range es.Events {
+			for _, event := range msg {
+				t.Logf("Event: %#v", event)
+				wait <- event
+				es.Stop()
+				return
+			}
+		}
+	}()
+
+	err = ioutil.WriteFile(filepath.Join(path, "example.txt"), []byte("example"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	<-wait
+}


### PR DESCRIPTION
It merges the upstream changes into this fork to be compatible with Go 1.10. 
Most of the changes come from https://github.com/fsnotify/fsevents/pull/34, afaik. According to the latest commits in that PR it's still compatible with Go 1.9.3+